### PR TITLE
feat: switch deployment from Vercel to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,8 +6,11 @@ const withMDX = NextMdx({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+	output: "export",
+	trailingSlash: true,
 	pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
 	images: {
+		unoptimized: true,
 		remotePatterns: [
 			{
 				protocol: "https",

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+atrai.bike

--- a/src/app/[lng]/page.tsx
+++ b/src/app/[lng]/page.tsx
@@ -5,6 +5,10 @@ import { redirect } from "next/navigation";
 import PageDialog from "./page-dialog";
 import H4 from "@/components/ui/typography/H4";
 
+export function generateStaticParams() {
+  return [{ lng: "de" }, { lng: "en" }, { lng: "pt" }];
+}
+
 export default async function Page({
   params,
 }: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,13 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
+"use client";
+
+import { useEffect } from "react";
 
 export default function Page() {
-	const language = headers().get("Accept-Language");
+	useEffect(() => {
+		const lang = navigator.language?.slice(0, 2);
+		const target = ["de", "en", "pt"].includes(lang) ? lang : "en";
+		window.location.replace(`/${target}/`);
+	}, []);
 
-	if (language?.includes("de")) {
-		redirect("/de");
-	}
-
-	if (language?.includes("pt")) {
-		redirect("/pt");
-	}
-
-	redirect("/en");
+	return null;
 }


### PR DESCRIPTION
- next.config.mjs: static export (output: "export"), unoptimized images, trailingSlash for static host routing
- app/[lng]/page.tsx: add generateStaticParams for de/en/pt, required for dynamic segments under static export
- app/page.tsx: replace server-side headers()-based locale redirect with a client-side redirect (no server available on Pages)
- public/CNAME: custom domain atrai.bike
- .github/workflows/deploy.yml: build and deploy ./out to GitHub Pages on push to main